### PR TITLE
global 패키지 global, common으로 분리

### DIFF
--- a/src/main/kotlin/com/gsmNetworking/chat/common/error/exception/ExpectedException.kt
+++ b/src/main/kotlin/com/gsmNetworking/chat/common/error/exception/ExpectedException.kt
@@ -1,6 +1,5 @@
-package com.gsmNetworking.chat.global.error.exception
+package com.gsmNetworking.chat.common.error.exception
 
-import com.gsmNetworking.chat.global.error.model.ErrorCode
 import org.springframework.http.HttpStatus
 
 open class ExpectedException(

--- a/src/main/kotlin/com/gsmNetworking/chat/common/error/model/ErrorCode.kt
+++ b/src/main/kotlin/com/gsmNetworking/chat/common/error/model/ErrorCode.kt
@@ -1,0 +1,5 @@
+package com.gsmNetworking.chat.common.error.model
+
+enum class ErrorCode {
+    DEFAULT
+}

--- a/src/main/kotlin/com/gsmNetworking/chat/common/error/model/ExceptionResponse.kt
+++ b/src/main/kotlin/com/gsmNetworking/chat/common/error/model/ExceptionResponse.kt
@@ -1,4 +1,4 @@
-package com.gsmNetworking.chat.global.error.model
+package com.gsmNetworking.chat.common.error.model
 
 class ExceptionResponse(
     val message: String

--- a/src/main/kotlin/com/gsmNetworking/chat/global/error/model/ErrorCode.kt
+++ b/src/main/kotlin/com/gsmNetworking/chat/global/error/model/ErrorCode.kt
@@ -1,5 +1,0 @@
-package com.gsmNetworking.chat.global.error.model
-
-enum class ErrorCode {
-    DEFAULT
-}

--- a/src/main/kotlin/com/gsmNetworking/chat/global/exception/handler/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/gsmNetworking/chat/global/exception/handler/GlobalExceptionHandler.kt
@@ -1,7 +1,7 @@
-package com.gsmNetworking.chat.global.error.handler
+package com.gsmNetworking.chat.global.exception.handler
 
-import com.gsmNetworking.chat.global.error.exception.ExpectedException
-import com.gsmNetworking.chat.global.error.model.ExceptionResponse
+import com.gsmNetworking.chat.common.error.exception.ExpectedException
+import com.gsmNetworking.chat.common.error.model.ExceptionResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice


### PR DESCRIPTION
## 개요
global 패키지를 global, common으로 분리하였습니다.

## 본문
### 분리한 이유
global 패키지에는 크게 2가지 유형의 객체가 존재합니다.
1. config, handler 처럼 설정 컴포넌트의 역할을 하는 객체
2. 도메인 패키지에서 전역으로 사용하는 Base 객체, Util 성 객체

같은 유형만 포함되도록 패키지를 분리하는 것이 더 좋은 아키텍처라고 생각하여 분리하게 되었습니다.
1번 유형의 객체는 global 패키지, 2번 유형의 객체는 common 패키지로 분리하였습니다.

### 변경 전 패키지 구조
  - global
    - error
      - exception
        - `ExpectedException`
      - model
        - `ErrorCode`
        - `ExceptionResponse`
      - handler
        - `GlobalExceptionHandler`

### 변경 후 패키지 구조
  - global
    - exception
      - handler
        - `GlobalExceptionHandler`
  - common
    - error
        - exception
          - `ExpectedException`
        - model
          - `ErrorCode`
          - `ExceptionResponse`